### PR TITLE
feat: Add image upload page and functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@testing-library/user-event": "^13.5.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-router-dom": "^7.6.1",
         "react-scripts": "5.0.1",
         "web-vitals": "^2.1.4"
       }
@@ -13932,6 +13933,50 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.1.tgz",
+      "integrity": "sha512-hPJXXxHJZEsPFNVbtATH7+MMX43UDeOauz+EAU4cgqTn7ojdI9qQORqS8Z0qmDlL1TclO/6jLRYUEtbWidtdHQ==",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.6.1.tgz",
+      "integrity": "sha512-vxU7ei//UfPYQ3iZvHuO1D/5fX3/JOqhNTbRR+WjSBWxf9bIvpWK+ftjmdfJHzPOuMQKe2fiEdG+dZX6E8uUpA==",
+      "dependencies": {
+        "react-router": "7.6.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/react-scripts": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-5.0.1.tgz",
@@ -14837,6 +14882,11 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ=="
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@testing-library/user-event": "^13.5.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-router-dom": "^7.6.1",
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4"
   },

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,78 @@
 import React, { useState, useEffect } from 'react';
+import { Routes, Route, Link } from 'react-router-dom'; // Add Link here
 import ApiService from './services/api';
 import './App.css';
+import UploadPage from './pages/UploadPage'; // Import UploadPage
+
+// Component for the Home Page content
+function HomePageContent({
+  connectionStatus,
+  loading,
+  error,
+  backendMessage,
+  refreshData,
+  testApiEndpoint
+}) {
+  return (
+    <>
+      {/* Connection Status */}
+      <div className="status-section">
+        <h2>Backend Connection</h2>
+        <p className={connectionStatus.includes('✅') ? 'success' : 'error'}>
+          {connectionStatus}
+        </p>
+      </div>
+
+      {/* Loading State */}
+      {loading && (
+        <div className="loading">
+          <p>Loading data from backend...</p>
+        </div>
+      )}
+
+      {/* Error State */}
+      {error && (
+        <div className="error">
+          <h3>Connection Error</h3>
+          <p>{error}</p>
+          <button onClick={refreshData} className="retry-button">
+            Retry Connection
+          </button>
+        </div>
+      )}
+
+      {/* Success State - Display Backend Message */}
+      {!loading && !error && backendMessage && (
+        <div className="content">
+          <h2>Message from FastAPI Backend:</h2>
+          <div className="message-box">
+            <p>"{backendMessage}"</p>
+          </div>
+        </div>
+      )}
+
+      {/* Action Buttons */}
+      <div className="actions">
+        <button onClick={refreshData} className="action-button">
+          Refresh Data
+        </button>
+        <button onClick={testApiEndpoint} className="action-button">
+          Test Health Endpoint
+        </button>
+      </div>
+
+      {/* Development Info */}
+      <div className="dev-info">
+        <h3>Development Info</h3>
+        <p><strong>Frontend:</strong> http://localhost:3000</p>
+        <p><strong>Backend:</strong> http://127.0.0.1:8000</p>
+        <p><strong>API Docs:</strong> <a href="http://127.0.0.1:8000/docs" target="_blank" rel="noopener noreferrer">http://127.0.0.1:8000/docs</a></p>
+      </div>
+    </>
+  );
+}
+
+// UploadPagePlaceholder function definition removed
 
 function App() {
   // State management
@@ -19,9 +91,7 @@ function App() {
     setError(null);
     
     try {
-      // Call the root endpoint of your FastAPI backend
       const response = await ApiService.get('/');
-      
       setBackendMessage(response.message || 'No message from backend');
       setConnectionStatus('✅ Connected to FastAPI');
     } catch (error) {
@@ -34,6 +104,8 @@ function App() {
   };
 
   const testApiEndpoint = async () => {
+    // Note: Original used alert(), keeping that behavior for now.
+    // Consider updating this to display message within the UI if preferred.
     try {
       const response = await ApiService.get('/api/health');
       alert(`Health check: ${response.status}`);
@@ -51,59 +123,27 @@ function App() {
       <header className="App-header">
         <h1>React + FastAPI Integration</h1>
         
-        {/* Connection Status */}
-        <div className="status-section">
-          <h2>Backend Connection</h2>
-          <p className={connectionStatus.includes('✅') ? 'success' : 'error'}>
-            {connectionStatus}
-          </p>
-        </div>
+        {/* Navigation Links */}
+        <nav style={{ marginBottom: '20px' }}>
+          <Link to="/" style={{ marginRight: '15px', color: 'white' }}>Home</Link>
+          <Link to="/upload" style={{ color: 'white' }}>Upload Image</Link>
+        </nav>
 
-        {/* Loading State */}
-        {loading && (
-          <div className="loading">
-            <p>Loading data from backend...</p>
-          </div>
-        )}
+        <Routes>
+          <Route
+            path="/"
+            element={<HomePageContent
+                        connectionStatus={connectionStatus}
+                        loading={loading}
+                        error={error}
+                        backendMessage={backendMessage}
+                        refreshData={refreshData}
+                        testApiEndpoint={testApiEndpoint}
+                      />}
+          />
+          <Route path="/upload" element={<UploadPage />} />
+        </Routes>
 
-        {/* Error State */}
-        {error && (
-          <div className="error">
-            <h3>Connection Error</h3>
-            <p>{error}</p>
-            <button onClick={refreshData} className="retry-button">
-              Retry Connection
-            </button>
-          </div>
-        )}
-
-        {/* Success State - Display Backend Message */}
-        {!loading && !error && backendMessage && (
-          <div className="content">
-            <h2>Message from FastAPI Backend:</h2>
-            <div className="message-box">
-              <p>"{backendMessage}"</p>
-            </div>
-          </div>
-        )}
-
-        {/* Action Buttons */}
-        <div className="actions">
-          <button onClick={refreshData} className="action-button">
-            Refresh Data
-          </button>
-          <button onClick={testApiEndpoint} className="action-button">
-            Test Health Endpoint
-          </button>
-        </div>
-
-        {/* Development Info */}
-        <div className="dev-info">
-          <h3>Development Info</h3>
-          <p><strong>Frontend:</strong> http://localhost:3000</p>
-          <p><strong>Backend:</strong> http://127.0.0.1:8000</p>
-          <p><strong>API Docs:</strong> <a href="http://127.0.0.1:8000/docs" target="_blank" rel="noopener noreferrer">http://127.0.0.1:8000/docs</a></p>
-        </div>
       </header>
     </div>
   );

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom'; // Import BrowserRouter
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
@@ -7,7 +8,9 @@ import reportWebVitals from './reportWebVitals';
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter> {/* Wrap App with BrowserRouter */}
+      <App />
+    </BrowserRouter>
   </React.StrictMode>
 );
 

--- a/src/pages/UploadPage.css
+++ b/src/pages/UploadPage.css
@@ -1,0 +1,66 @@
+.upload-page-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 20px;
+  text-align: center;
+}
+
+.upload-form {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px; /* Spacing between elements */
+  border: 1px solid #ccc;
+  padding: 30px;
+  border-radius: 8px;
+  background-color: #f9f9f9;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  margin-top: 20px;
+}
+
+.file-input {
+  padding: 10px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+}
+
+.upload-button {
+  padding: 10px 20px;
+  background-color: #007bff;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 16px;
+}
+
+.upload-button:disabled {
+  background-color: #ccc;
+  cursor: not-allowed;
+}
+
+.upload-button:hover:not(:disabled) {
+  background-color: #0056b3;
+}
+
+.upload-status {
+  margin-top: 15px;
+  font-size: 14px;
+  color: #333;
+}
+
+.image-preview-container {
+  margin-top: 15px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.image-preview {
+  max-width: 300px; /* Limit preview width */
+  max-height: 300px; /* Limit preview height */
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  margin-top: 10px;
+}

--- a/src/pages/UploadPage.js
+++ b/src/pages/UploadPage.js
@@ -1,0 +1,86 @@
+import React, { useState } from 'react';
+import ApiService from '../services/api'; // Import ApiService
+import './UploadPage.css'; // We'll create this basic CSS file as well
+
+function UploadPage() {
+  const [selectedFile, setSelectedFile] = useState(null);
+  const [uploadStatus, setUploadStatus] = useState(''); // To display messages like "Uploading...", "Success!", "Error"
+  const [previewUrl, setPreviewUrl] = useState(''); // To display a preview of the selected image
+
+  const handleFileChange = (event) => {
+    const file = event.target.files[0];
+    if (file) {
+      setSelectedFile(file);
+      setUploadStatus(`File selected: ${file.name}`);
+      // Create a preview URL
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        setPreviewUrl(reader.result);
+      };
+      reader.readAsDataURL(file);
+    } else {
+      setSelectedFile(null);
+      setPreviewUrl('');
+      setUploadStatus('');
+    }
+  };
+
+  const handleUpload = async () => {
+    if (!selectedFile) {
+      setUploadStatus('Please select a file first.');
+      return;
+    }
+
+    setUploadStatus(`Uploading ${selectedFile.name}...`);
+
+    try {
+      // Use the ApiService to upload the image
+      // The backend endpoint is assumed to be /api/upload-image
+      const response = await ApiService.uploadImage('/api/upload-image', selectedFile);
+
+      setUploadStatus(`Successfully uploaded ${selectedFile.name}: ${response.message || 'Success!'}`); // Assuming backend sends a message
+      setSelectedFile(null); // Clear the selected file
+      setPreviewUrl('');     // Clear the preview
+      // Optionally, reset file input visually if possible (tricky, often involves re-rendering the input with a key)
+      // For simplicity, we'll rely on selectedFile being null to disable the button and clear preview.
+
+    } catch (error) {
+      console.error('Upload failed:', error);
+      // Display a more user-friendly error message if possible
+      // error.message might contain the detailed error from ApiService
+      setUploadStatus(`Upload failed: ${error.message || 'Could not connect to server or server returned an error.'}`);
+    }
+  };
+
+  return (
+    <div className="upload-page-container">
+      <h2>Upload Image</h2>
+      <div className="upload-form">
+        <input
+          type="file"
+          accept="image/*"
+          onChange={handleFileChange}
+          // To help reset the input field visually after successful upload or if the user re-selects
+          // we can control it by making it a "controlled" component if needed, or simply by key.
+          // For now, we'll keep it simple. The browser usually handles clearing it if the same file is chosen again.
+          // If we clear `selectedFile` and `previewUrl`, the visual feedback should be sufficient.
+          className="file-input"
+          // Add a key that changes when the file is cleared to force re-render of the input
+          key={selectedFile ? 'file-selected' : 'file-not-selected'}
+        />
+        {previewUrl && (
+          <div className="image-preview-container">
+            <p>Selected image preview:</p>
+            <img src={previewUrl} alt="Selected preview" className="image-preview" />
+          </div>
+        )}
+        <button onClick={handleUpload} disabled={!selectedFile || uploadStatus.startsWith('Uploading')} className="upload-button">
+          {uploadStatus.startsWith('Uploading') ? 'Uploading...' : 'Upload Image'}
+        </button>
+        {uploadStatus && <p className="upload-status">{uploadStatus}</p>}
+      </div>
+    </div>
+  );
+}
+
+export default UploadPage;

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -11,13 +11,15 @@ class ApiService {
           'Content-Type': 'application/json',
         },
       });
-      
+
       if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
+        // Construct a more informative error message
+        const errorBody = await response.text(); // Try to get error body
+        throw new Error(`HTTP error! status: ${response.status}, statusText: ${response.statusText}, body: ${errorBody}`);
       }
-      
+
       const data = await response.json();
-      console.log('API Response:', data);
+      console.log('API GET Response:', data);
       return data;
     } catch (error) {
       console.error('API GET error:', error);
@@ -27,7 +29,7 @@ class ApiService {
 
   async post(endpoint, data) {
     try {
-      console.log(`Making POST request to: ${API_BASE_URL}${endpoint}`);
+      console.log(`Making POST request (JSON) to: ${API_BASE_URL}${endpoint}`);
       const response = await fetch(`${API_BASE_URL}${endpoint}`, {
         method: 'POST',
         headers: {
@@ -35,16 +37,45 @@ class ApiService {
         },
         body: JSON.stringify(data),
       });
-      
+
       if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
+        const errorBody = await response.text();
+        throw new Error(`HTTP error! status: ${response.status}, statusText: ${response.statusText}, body: ${errorBody}`);
       }
-      
+
       const result = await response.json();
-      console.log('API Response:', result);
+      console.log('API POST (JSON) Response:', result);
       return result;
     } catch (error) {
-      console.error('API POST error:', error);
+      console.error('API POST (JSON) error:', error);
+      throw error;
+    }
+  }
+
+  async uploadImage(endpoint, file) {
+    try {
+      console.log(`Making POST request (file upload) to: ${API_BASE_URL}${endpoint}`);
+      const formData = new FormData();
+      formData.append('image', file); // 'image' is a common field name for the file
+
+      const response = await fetch(`${API_BASE_URL}${endpoint}`, {
+        method: 'POST',
+        // NOTE: Do NOT set 'Content-Type' manually for FormData.
+        // The browser will automatically set it to 'multipart/form-data'
+        // with the correct boundary.
+        body: formData,
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.text();
+        throw new Error(`HTTP error! status: ${response.status}, statusText: ${response.statusText}, body: ${errorBody}`);
+      }
+
+      const result = await response.json(); // Assuming the backend responds with JSON
+      console.log('API File Upload Response:', result);
+      return result;
+    } catch (error) {
+      console.error('API File Upload error:', error);
       throw error;
     }
   }


### PR DESCRIPTION
This commit introduces a new page at `/upload` that allows you to select an image from your device and upload it.

Key changes include:
- Added `react-router-dom` for routing.
- Configured routes in `App.js` for the home page and the new `/upload` page.
- Created `UploadPage.js` component with:
  - File input for image selection (accepts image/*).
  - Preview of the selected image.
  - State management for selected file, preview, and upload status.
- Updated `ApiService.js` to include an `uploadImage` method:
  - Uses `FormData` to send the image file.
  - Correctly omits manual `Content-Type` header for `multipart/form-data`.
  - Enhanced error handling in existing API methods.
- Integrated `ApiService.uploadImage` into `UploadPage.js` to handle the upload process, including success and error feedback.
- Added navigation links in `App.js` to switch between the Home and Upload pages.

The backend endpoint `/api/upload-image` is assumed to be available and configured to handle the image upload. I've reviewed the code flow to ensure the frontend is working as expected.